### PR TITLE
feat: allow pytorch weight loaded as tf weights for bert models

### DIFF
--- a/rasa/nlu/featurizers/dense_featurizer/lm_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/lm_featurizer.py
@@ -35,6 +35,7 @@ MAX_SEQUENCE_LENGTHS = {
     "distilbert": 512,
     "roberta": 512,
     "camembert": 512,
+    "other": 512
 }
 
 
@@ -152,9 +153,15 @@ class LanguageModelFeaturizer(DenseFeaturizer, GraphComponent):
         self.tokenizer = model_tokenizer_dict[self.model_name].from_pretrained(
             self.model_weights, cache_dir=self.cache_dir
         )
-        self.model = model_class_dict[self.model_name].from_pretrained(
-            self.model_weights, cache_dir=self.cache_dir
-        )
+        if self.model_name == "other":
+            #always load pytorch weights
+            self.model = model_class_dict[self.model_name].from_pretrained(
+                self.model_weights, cache_dir=self.cache_dir, from_pt= True
+            )
+        else:
+            self.model = model_class_dict[self.model_name].from_pretrained(
+                self.model_weights, cache_dir=self.cache_dir
+            )
 
         # Use a universal pad token since all transformer architectures do not have a
         # consistent token. Instead of pad_token_id we use unk_token_id because

--- a/rasa/nlu/utils/hugging_face/registry.py
+++ b/rasa/nlu/utils/hugging_face/registry.py
@@ -15,6 +15,7 @@ from transformers import (  # noqa: E402
     TFDistilBertModel,
     TFRobertaModel,
     TFCamembertModel,
+    TFAutoModel,
     PreTrainedTokenizer,
     BertTokenizer,
     OpenAIGPTTokenizer,
@@ -24,6 +25,7 @@ from transformers import (  # noqa: E402
     DistilBertTokenizer,
     RobertaTokenizer,
     CamembertTokenizer,
+    AutoTokenizer
 )
 from rasa.nlu.utils.hugging_face.transformers_pre_post_processors import (  # noqa: E402, E501
     bert_tokens_pre_processor,
@@ -52,6 +54,7 @@ model_class_dict: Dict[Text, Type[TFPreTrainedModel]] = {
     "distilbert": TFDistilBertModel,
     "roberta": TFRobertaModel,
     "camembert": TFCamembertModel,
+    "other": TFAutoModel
 }
 model_tokenizer_dict: Dict[Text, Type[PreTrainedTokenizer]] = {
     "bert": BertTokenizer,
@@ -62,6 +65,7 @@ model_tokenizer_dict: Dict[Text, Type[PreTrainedTokenizer]] = {
     "distilbert": DistilBertTokenizer,
     "roberta": RobertaTokenizer,
     "camembert": CamembertTokenizer,
+    "other": AutoTokenizer
 }
 model_weights_defaults = {
     "bert": "rasa/LaBSE",
@@ -72,6 +76,7 @@ model_weights_defaults = {
     "distilbert": "distilbert-base-uncased",
     "roberta": "roberta-base",
     "camembert": "camembert-base",
+    "other": "sentence-transformers/all-MiniLM-L6-v2"
 }
 
 model_special_tokens_pre_processors = {
@@ -83,6 +88,7 @@ model_special_tokens_pre_processors = {
     "distilbert": bert_tokens_pre_processor,
     "roberta": roberta_tokens_pre_processor,
     "camembert": camembert_tokens_pre_processor,
+    "other": bert_tokens_pre_processor,
 }
 
 model_tokens_cleaners = {
@@ -94,6 +100,7 @@ model_tokens_cleaners = {
     "distilbert": bert_tokens_cleaner,  # uses the same as BERT
     "roberta": gpt2_tokens_cleaner,  # Uses the same as GPT2
     "camembert": xlnet_tokens_cleaner,  # Removing underscores _
+    "other": bert_tokens_cleaner
 }
 
 model_embeddings_post_processors = {
@@ -105,4 +112,5 @@ model_embeddings_post_processors = {
     "distilbert": bert_embeddings_post_processor,
     "roberta": roberta_embeddings_post_processor,
     "camembert": roberta_embeddings_post_processor,
+    "other": bert_embeddings_post_processor
 }


### PR DESCRIPTION
### Description

In this pull request, we are making changes in some files related to Hugging Face transformers in the Rasa NLU module. The key changes include:

- Registering a new model type named "other" for Hugging Face transformers to load a pre-trained model with PyTorch weights.
- Adding support for "other" model type in the `_load_model_instance` method to load the model with PyTorch weights if the model name is "other".
- Introducing a new class `TFAutoModel` and `AutoTokenizer` to handle the "other" model type.
- Updating model configurations, tokenizer mappings, default weights, special tokens pre-processors, token cleaners, and embeddings post-processors for the "other" model type.

These changes enhance the flexibility of Rasa NLU by allowing it to work with additional transformer models that may have unique specifications, especially when dealing with PyTorch weights.

No further details or requirements have been provided at this time.